### PR TITLE
Bugfix issue 4

### DIFF
--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -1,7 +1,7 @@
 package domain
 
 import (
-	"github.com/unknowntpo/todos/internal/domain/errors"
+	"errors"
 )
 
 var (

--- a/internal/user/usecase/user_usecase.go
+++ b/internal/user/usecase/user_usecase.go
@@ -93,7 +93,7 @@ func (uu *userUsecase) Login(ctx context.Context, email, password string) (*doma
 
 	user, err := uu.userRepo.GetByEmail(ctx, email)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(op, errors.KindInvalidCredentials, err)
 	}
 
 	// Check if the provided password matches the actual password for the user.


### PR DESCRIPTION

This PR fix the bug in Issue #4, and make sure the origin of the error stack trace is at the caller of `errors.E(errors.ErrRecordNotFound)`.

Like

```
{
  "level": "error",
  "stack": [
    {
      "func": "E",
      "line": "232",
      "source": "errors.go"
    },
    {
      "func": "(*userRepo).GetByEmail",
      "line": "76",
      "source": "postgres_repo.go"
    },
    {
      "func": "(*userUsecase).Login",
      "line": "94",
      "source": "user_usecase.go"
    },
    {
      "func": "(*tokenAPI).CreateAuthenticationToken",
      "line": "64",
      "source": "token_api.go"
    },
    {
      "func": "HandlerFunc.ServeHTTP",
      "line": "2050",
      "source": "server.go"
    },
    {
      "func": "(*Router).Handler.func1",
      "line": "275",
      "source": "router.go"
    },
    {
      "func": "(*Router).ServeHTTP",
      "line": "387",
      "source": "router.go"
    },
    {
      "func": "(*Middleware).Authenticate.func1",
      "line": "123",
      "source": "middleware.go"
    },
    {
      "func": "HandlerFunc.ServeHTTP",
      "line": "2050",
      "source": "server.go"
    },
    {
      "func": "(*Middleware).RateLimit.func2",
      "line": "108",
      "source": "middleware.go"
    },
    {
      "func": "HandlerFunc.ServeHTTP",
      "line": "2050",
      "source": "server.go"
    },
    {
      "func": "(*Middleware).EnableCORS.func1",
      "line": "262",
      "source": "middleware.go"
    },
    {
      "func": "HandlerFunc.ServeHTTP",
      "line": "2050",
      "source": "server.go"
    },
    {
      "func": "(*Middleware).RecoverPanic.func1",
      "line": "43",
      "source": "middleware.go"
    },
    {
      "func": "HandlerFunc.ServeHTTP",
      "line": "2050",
      "source": "server.go"
    },
    {
      "func": "serverHandler.ServeHTTP",
      "line": "2868",
      "source": "server.go"
    },
    {
      "func": "(*conn).serve",
      "line": "1933",
      "source": "server.go"
    },
    {
      "func": "goexit",
      "line": "1371",
      "source": "asm_amd64.s"
    }
  ],
  "error": "tokenAPI.CreateAuthenticationToken: >> userUsecase.Login: >> userRepo.GetByEmail: kind record not found: >> record not found",
  "time": "2021-12-06T02:55:37Z"
}
```

Not like the problem described in https://github.com/unknowntpo/todos/issues/4#issuecomment-985155437

